### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,5 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/hadimichael/gest.js.git"
-	},
+	}
 }


### PR DESCRIPTION
Hi! Currently package.json has an extra comma, giving the following error upon installation: 
```
npm ERR! Failed to parse json
npm ERR! Trailing comma in object at 10:1
npm ERR! }
npm ERR! ^
npm ERR! File: /var/folders/54/zqj9kxq17yl0ckzr738d_9c0mlyy56/T/npm-65694-c9384f76/git-cache-a959c3fb/ea2390d761d4a3e363b9e9b4cc2906de3173aef1/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR!
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse
```